### PR TITLE
Revert "Relatively good random"

### DIFF
--- a/app/(main)/home/participants.tsx
+++ b/app/(main)/home/participants.tsx
@@ -31,31 +31,21 @@ function distributePlayers(
 ): Participant[][] {
   const teams: Participant[][] = teamSizes.map(() => []);
 
-  // Sort participants by skill score in descending order
   const sortedParticipants = [...participants].sort(
     (a, b) => b.skillsScore - a.skillsScore
   );
 
-  // Define a function to shuffle an array
-  function shuffle(array: Participant[]): Participant[] {
-    for (let i = array.length - 1; i > 0; i--) {
-      const randomIndex = Math.floor(Math.random() * (i + 1));
-      [array[i], array[randomIndex]] = [array[randomIndex], array[i]];
+  let direction = 1;
+  let teamIndex = 0;
+
+  for (const participant of sortedParticipants) {
+    teams[teamIndex].push(participant);
+
+    teamIndex += direction;
+    if (teamIndex === teams.length || teamIndex < 0) {
+      direction *= -1;
+      teamIndex += direction;
     }
-    return array;
-  }
-
-  const numTeams = teams.length;
-  
-  // Divide and shuffle participants in chunks of size equal to the number of teams
-  for (let i = 0; i < sortedParticipants.length; i += numTeams) {
-    const chunk = sortedParticipants.slice(i, i + numTeams);
-    const shuffledChunk = shuffle(chunk);
-
-    // Distribute shuffled participants of the current chunk across teams
-    shuffledChunk.forEach((participant, index) => {
-      teams[index].push(participant);
-    });
   }
 
   return teams;


### PR DESCRIPTION
@ameti  @edmondshtogu  The random shuffle worked, however i am reverting this feature because of the following issues: 

1. Currently the app doesn't have very clean state management and caching, therefore on every render the teams will be shuffled. This will cause confusion as everybody will see something different and everytime we open the app the teams will be different. (As you know conversations in our whatsapp group take longer even for smaller things, therefore we don't want that :) )
2. I was able to quickly fix the issue above by refactoring and introducing better state management and also caching through localStorage. However another issue came up and basically users can manually leave/join and everytime that happens the teams are shuffled. This way any participant can shuffle the teams as they wish by just leaving and joining, which would cause confusion and also a bad user experience in the app. 

So i propose that we revert this and introduce it later with a more sophisticated teams update based on the participants list. This way we will have the shuffle and also no unwanted behaviours through bugs. 

P.S ( i will merge this PR till Thursday EOD so feel free to leave a comment if u have any questions/ideas)