### PR TITLE
feat: distribute teams by gender

### DIFF
--- a/__tests__/teams.test.ts
+++ b/__tests__/teams.test.ts
@@ -11,7 +11,7 @@ const p = (id: number, skillsScore: number, gender: string): Participant => ({
 } as Participant);
 
 describe('distributePlayers', () => {
-  it('should sort participants by gender (males first) and then  distribute', () => {
+  it('should sort participants by gender and then  distribute', () => {
     const participants: Participant[] = [
       p(1, 5, 'male'),
       p(2, 5, 'female'),
@@ -94,6 +94,38 @@ describe('distributePlayers', () => {
 
     const genderDifference = Math.abs(maxFemalesCount - minFemalesCount);
 
+    expect(genderDifference).toBeLessThanOrEqual(1);
+  });
+
+  it('should sort participants by gender - uneven teams uneven gender number ', () => {
+    const participants: Participant[] = [
+      p(1, 5, 'male'),
+      p(2, 7, 'male'),
+      p(3, 9, 'male'),
+      p(4, 11, 'male'),
+      p(5, 13, 'male'),
+      p(6, 14, 'male'),
+      p(7, 16, 'male'),
+      p(8, 18, 'male'),
+      p(9, 20, 'male'),
+      p(10, 5, 'female'),
+      p(11, 10, 'female'),
+      p(12, 15, 'female'),
+      p(13, 20, 'female'),
+      p(14, 22, 'female')
+    ];
+
+    const teamSizes = [4, 4, 4, 4];
+    const result = distributePlayers(participants, teamSizes);
+
+    const minFemalesCount = Math.min(...result.map(team => team.filter(p =>
+      p.gender === 'female').length));
+    const maxFemalesCount = Math.max(...result.map(team => team.filter(p =>
+      p.gender === 'female').length));
+
+    const genderDifference = Math.abs(maxFemalesCount - minFemalesCount);
+
+    //assert that the difference between max and min is less than or equal to 1
     expect(genderDifference).toBeLessThanOrEqual(1);
   });
 });

--- a/__tests__/teams.test.ts
+++ b/__tests__/teams.test.ts
@@ -1,0 +1,99 @@
+import { Participant } from '@/lib/models';
+import {
+  distributePlayers
+} from '../app/(main)/home/teams';
+
+const p = (id: number, skillsScore: number, gender: string): Participant => ({
+  playerId: id,
+  name: `P-${id}`,
+  skillsScore,
+  gender
+} as Participant);
+
+describe('distributePlayers', () => {
+  it('should sort participants by gender (males first) and then  distribute', () => {
+    const participants: Participant[] = [
+      p(1, 5, 'male'),
+      p(2, 5, 'female'),
+      p(3, 8, 'male'),
+      p(4, 8, 'female'),
+      p(5, 12, 'male'),
+      p(6, 12, 'female'),
+      p(7, 16, 'male'),
+      p(8, 16, 'female'),
+      p(9, 22, 'male'),
+      p(10, 23, 'male'),
+      p(11, 18, 'male'),
+      p(12, 30, 'female'),
+      p(13, 10, 'female'),
+      p(14, 9, 'male'),
+      p(15, 15, 'female'),
+      p(16, 18, 'female')
+    ];
+
+    const teamSizes = [4, 4, 4, 4];
+    const result = distributePlayers(participants, teamSizes);
+
+    const minFemalesCount = Math.min(...result.map(team => team.filter(p =>
+      p.gender === 'female').length));
+    const maxFemalesCount = Math.max(...result.map(team => team.filter(p =>
+      p.gender === 'female').length));
+
+    const genderDifference = Math.abs(maxFemalesCount - minFemalesCount);
+
+    //assert that the difference between max and min is less than or equal to 1
+    expect(genderDifference).toBeLessThanOrEqual(1);
+  });
+
+  it('should correctly distribute male and female players when uneven numbers', () => {
+    const participants: Participant[] = [
+      p(1, 20, 'female'),
+      p(2, 2, 'female'),
+      p(3, 3, 'female'),
+      p(4, 4, 'female'),
+      p(5, 1, 'female'),
+      p(6, 20, 'male'),
+      p(7, 3, 'male'),
+      p(8, 4, 'male')
+    ];
+    const teamSizes = [4, 4];
+    const result = distributePlayers(participants, teamSizes);
+
+    const minFemalesCount = Math.min(...result.map(team => team.filter(p =>
+      p.gender === 'female').length));
+    const maxFemalesCount = Math.max(...result.map(team => team.filter(p =>
+      p.gender === 'female').length));
+
+    const genderDifference = Math.abs(maxFemalesCount - minFemalesCount);
+
+    expect(genderDifference).toBeLessThanOrEqual(1);
+  });
+
+  it('should return empty teams if no participants are provided', () => {
+    const participants: Participant[] = [];
+    const teamSizes = [0, 0];
+    const result = distributePlayers(participants, teamSizes);
+    expect(result).toEqual([[], []]);
+  });
+
+  it('should distribute players evenly when team sizes are not equal', () => {
+    const participants: Participant[] = [
+      p(1, 5, 'female'),
+      p(2, 4, 'female'),
+      p(3, 3, 'male'),
+      p(4, 2, 'male'),
+      p(5, 1, 'female')
+    ];
+    const teamSizes = [3, 2];
+    const result = distributePlayers(participants, teamSizes);
+
+    const minFemalesCount = Math.min(...result.map(team => team.filter(p =>
+      p.gender === 'female').length));
+    const maxFemalesCount = Math.max(...result.map(team => team.filter(p =>
+      p.gender === 'female').length));
+
+    const genderDifference = Math.abs(maxFemalesCount - minFemalesCount);
+
+    expect(genderDifference).toBeLessThanOrEqual(1);
+  });
+});

--- a/app/(main)/home/participants.tsx
+++ b/app/(main)/home/participants.tsx
@@ -25,48 +25,7 @@ import {
   deleteParticipants,
   updateFieldsNumber,
 } from './actions';
-
-function distributePlayers(
-  participants: Participant[],
-  teamSizes: number[]
-): Participant[][] {
-  const teams: Participant[][] = teamSizes.map(() => []);
-
-  const sortedParticipants = [...participants].sort(
-    (a, b) => b.skillsScore - a.skillsScore
-  );
-
-  let direction = 1;
-  let teamIndex = 0;
-
-  for (const participant of sortedParticipants) {
-    teams[teamIndex].push(participant);
-
-    teamIndex += direction;
-    if (teamIndex === teams.length || teamIndex < 0) {
-      direction *= -1;
-      teamIndex += direction;
-    }
-  }
-
-  return teams;
-}
-
-function calculateTeamSizes(totalPlayers: number, maxTeamSize = 5, fieldsNumber: null | number): number[] {
-  // Calculate the number of fields needed based on max team size if fieldsNumber is not provided
-  const numberOfFields = fieldsNumber || Math.ceil(totalPlayers / (maxTeamSize * 2));
-  const numberOfTeams = numberOfFields * 2;
-  const baseSize = Math.floor(totalPlayers / numberOfTeams);
-  const remainder = totalPlayers % numberOfTeams;
-
-  const teamSizes = Array(numberOfTeams).fill(baseSize);
-
-  for (let i = 0; i < remainder; i++) {
-    teamSizes[i]++;
-  }
-
-  return teamSizes;
-}
+import { calculateTeamSizes, distributePlayers } from './teams';
 
 export type ParticipantsParam = {
   eventId: number | undefined;

--- a/app/(main)/home/participants.tsx
+++ b/app/(main)/home/participants.tsx
@@ -307,7 +307,9 @@ export function ParticipantsList({
                   </CardHeader>
                   <CardContent className='players-list'>
                     <ol>
-                      {team.map((participant, i) => (
+                      {team
+                        .sort((p1, p2) => p2.skillsScore - p1.skillsScore)
+                        .map((participant, i) => (
                         <li key={participant.playerId} className="flex items-center justify-between py-1 border-b border-gray-100 last:border-b-0">
                           <span className="font-medium">
                             <span className="inline-block w-6 text-gray-500">{i + 1}.</span>

--- a/app/(main)/home/participants.tsx
+++ b/app/(main)/home/participants.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import {
   Card,
   CardHeader,
@@ -52,6 +52,21 @@ export function ParticipantsList({
   const [hasChanges, setHasChanges] = useState(false);
   const [showBadges, setShowBadges] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+
+  const maxTeamSize = 6;
+  const teamSizes = useMemo(() => {
+    if (!participants || participants.length === 0 || !fieldsNumber) {
+      return [];
+    }
+    return calculateTeamSizes(participants.length, maxTeamSize, fieldsNumber);
+  }, [participants, fieldsNumber]);
+
+  const teams = useMemo(() => {
+    if (!participants || participants.length === 0 || teamSizes.length === 0) {
+      return [];
+    }
+    return distributePlayers(participants, teamSizes);
+  }, [participants, teamSizes]);
 
   useEffect(() => {
     if (!participants || participants.length === 0) {
@@ -251,10 +266,6 @@ export function ParticipantsList({
       </Card>
     );
   }
-
-  const maxTeamSize = 6;
-  const teamSizes = calculateTeamSizes(participants.length, maxTeamSize, fieldsNumber);
-  const teams = distributePlayers(participants, teamSizes);
 
   return (
     <Card>

--- a/app/(main)/home/teams.ts
+++ b/app/(main)/home/teams.ts
@@ -1,0 +1,46 @@
+import { Participant } from '@/lib/models';
+
+export function distributePlayers(
+  participants: Participant[],
+  teamSizes: number[]
+): Participant[][] {
+  const teams: Participant[][] = teamSizes.map(() => []);
+
+  const females = participants.filter(p => p.gender === 'female')
+    .sort((a, b) => b.skillsScore - a.skillsScore); // high skill first
+  const males   = participants.filter(p => p.gender !== 'female')
+    .sort((a, b) => b.skillsScore - a.skillsScore)
+
+  const sortedParticipants = [...males,...females];
+
+  let direction = 1;
+  let teamIndex = 0;
+
+  for (const participant of sortedParticipants) {
+    teams[teamIndex].push(participant);
+
+    teamIndex += direction;
+    if (teamIndex === teams.length || teamIndex < 0) {
+      direction *= -1;
+      teamIndex += direction;
+    }
+  }
+
+  return teams;
+}
+
+export function calculateTeamSizes(totalPlayers: number, maxTeamSize = 5, fieldsNumber: null | number): number[] {
+  // Calculate the number of fields needed based on max team size if fieldsNumber is not provided
+  const numberOfFields = fieldsNumber || Math.ceil(totalPlayers / (maxTeamSize * 2));
+  const numberOfTeams = numberOfFields * 2;
+  const baseSize = Math.floor(totalPlayers / numberOfTeams);
+  const remainder = totalPlayers % numberOfTeams;
+
+  const teamSizes = Array(numberOfTeams).fill(baseSize);
+
+  for (let i = 0; i < remainder; i++) {
+    teamSizes[i]++;
+  }
+
+  return teamSizes;
+}

--- a/app/(main)/home/teams.ts
+++ b/app/(main)/home/teams.ts
@@ -11,7 +11,7 @@ export function distributePlayers(
   const males   = participants.filter(p => p.gender !== 'female')
     .sort((a, b) => b.skillsScore - a.skillsScore)
 
-  const sortedParticipants = [...males,...females];
+  const sortedParticipants = [...females,...males];
 
   let direction = 1;
   let teamIndex = 0;


### PR DESCRIPTION
Order participants by gender and then distribute them into teams using the current logic.

This might cause bigger difference in the skill between team with highest score and with lowest score but the genders will be distributed equally.